### PR TITLE
add deep learning packages

### DIFF
--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -13,6 +13,9 @@ dependencies:
   - scikit-image=0.14.2
   - scikit-learn=0.20.3
   - dask-ml=0.12.0
+  - tensorflow=1.10.0
+  - keras=2.2.4
+  - pytorch-cpu=1.0.1
   # dask-related
   - dask=1.1.4
   - distributed=1.26.1

--- a/pangeo-notebook/binder/tests/test_imports.py
+++ b/pangeo-notebook/binder/tests/test_imports.py
@@ -7,7 +7,9 @@ packages = [
     # to dependencies outside the python world
     'netCDF4', 'h5py', 'rasterio', 'geopandas', 'cartopy', 'geoviews',
     # these are things we can't live without, just to be safe
-    'gcsfs', 's3fs', 'xarray', 'intake', 'dask', 'distributed'
+    'gcsfs', 's3fs', 'xarray', 'intake', 'dask', 'distributed',
+    # machine learning stuff
+    'tensorflow', 'keras', 'torch'
     ]
 
 @pytest.mark.parametrize('package_name', packages, ids=packages)


### PR DESCRIPTION
Adds tensorflow, keras, and pytorch.

As long as #23 remains unresolved, we can't use the gpu-optimized versions of the libraries because they are not available on conda forge.