### PR TITLE
Provide -onbuild variants of all images

### DIFF
--- a/docker_push.sh
+++ b/docker_push.sh
@@ -12,3 +12,12 @@ docker tag ${IMAGE_NAME} ${IMAGE_LATEST}
 
 docker push ${IMAGE_NAME}
 docker push ${IMAGE_LATEST}
+
+
+ONBUILD_IMAGE_NAME=${IMAGE_PREFIX}${IMAGE}-onbuild:${CALVER}
+ONBUILD_IMAGE_LATEST=${IMAGE_PREFIX}${IMAGE}-onbuild:latest
+
+docker tag ${ONBUILD_IMAGE_NAME} ${ONBUILD_IMAGE_LATEST}
+
+docker push ${ONBUILD_IMAGE_NAME}
+docker push ${ONBUILD_IMAGE_LATEST}

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -1,0 +1,14 @@
+FROM {base_image_spec}
+
+USER root
+COPY r2d_overlay.py /usr/local/bin/r2d_overlay.py
+
+ONBUILD COPY --chown=1000:1000 . ${REPO_DIR}
+# We copy contents of *child* image to a subdirectory temporarily
+# This helps us apply customizations that were only from the
+# child, and re-do the packages of the parent.
+ONBUILD COPY --chown=1000:1000 . ${REPO_DIR}/.onbuild-child
+ONBUILD RUN /usr/local/bin/r2d_overlay.py build
+ONBUILD RUN rm -rf ${REPO_DIR}/.onbuild-child
+
+ONBUILD USER ${NB_USER}

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -1,4 +1,5 @@
-FROM {base_image_spec}
+ARG BASE_IMAGE_SPEC
+FROM $BASE_IMAGE_SPEC
 
 USER root
 COPY r2d_overlay.py /usr/local/bin/r2d_overlay.py

--- a/onbuild/r2d_overlay.py
+++ b/onbuild/r2d_overlay.py
@@ -60,7 +60,8 @@ def apply_postbuild():
     if os.path.exists(pb_path):
         return [
             f'chmod +x {pb_path}',
-            f'./{pb_path}'
+            # since pb_path is a fully qualified path, no need to add a ./
+            f'{pb_path}'
         ]
 
 

--- a/onbuild/r2d_overlay.py
+++ b/onbuild/r2d_overlay.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import os
+import argparse
+
+NB_UID = int(os.environ.get('NB_UID', 1000))
+REPO_DIR = os.environ['REPO_DIR']
+# We copy contents of *child* image to a subdirectory temporarily
+# This helps us apply customizations that were only from the
+# child, and re-do the packages of the parent.
+ONBUILD_CONTENTS_DIR = os.path.join(REPO_DIR, '.onbuild-child')
+
+def become(uid):
+    # FIXME: Uh, maybe not do this
+    os.setgid(uid)
+    os.setuid(uid)
+
+def binder_path(path):
+    if os.path.exists(os.path.join(ONBUILD_CONTENTS_DIR, 'binder')):
+        return os.path.join(ONBUILD_CONTENTS_DIR, 'binder', path)
+    return os.path.join(ONBUILD_CONTENTS_DIR, path)
+
+
+def apply_environment():
+    env_path = binder_path('environment.yml')
+    if os.path.exists(env_path):
+        return [
+            f'conda env update -n root -f {env_path}',
+            f'conda clean -tipsy',
+            f'conda list -n root',
+            f'rm -rf /srv/conda/pkgs'
+        ]
+
+
+def apply_requirements():
+    req_path = binder_path('requirements.txt')
+    env_path = binder_path('environment.yml')
+
+    if os.path.exists(req_path) and not os.path.exists(env_path):
+        return [
+            f'python3 -m pip install --no-cache-dir -r {req_path}'
+        ]
+
+
+def apply_postbuild():
+    pb_path = binder_path('postBuild')
+
+    if os.path.exists(pb_path):
+        return [
+            f'chmod +x {pb_path}',
+            f'./{pb_path}'
+        ]
+
+
+def build():
+    applicators = [
+        apply_environment,
+        apply_requirements,
+        apply_postbuild
+    ]
+
+    for applicator in applicators:
+        commands = applicator()
+
+        if commands:
+            for command in commands:
+                subprocess.check_call(
+                    ['/bin/bash', '-c', command], preexec_fn=become(NB_UID)
+                )
+
+
+def main():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        'action',
+        choices=('build', 'start')
+    )
+
+    args = argparser.parse_args()
+
+    if args.action == 'build':
+        build()
+    else:
+        raise Exception("start isn't implemented yet")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This lets people use our images as a base, but
customize it easily with a subset of the files
understood by repo2docker. Currently, this includes:

- environment.yml
- requirements.txt
- postBuild
- apt.txt

We can add more if necessary.

The contents of the user's repository are also copied
into ${HOME}, merging with (and overwriting) anything
that's in our base images.

To use the onbuild images as a base,

1. In your git repository, create a file named 'Dockerfile'
2. Write the name of the base image you would like to use
    in the following format:

    'FROM <base-image>:<tag>'

    For example, you can write:

    'FROM pangeo/base-notebook-onbuild:2019.04.15'

    Note the -onbuild - that is very important.
3. Create a 'environment.yml', 'requirements.txt' or
    'postBuild' file in your repository (or under a
    'binder/' directory) to customize your environment
    when launched in a binder.

That's it! When this repository is launched in any
binder, your customizations will be applied on top
of the base image you have chosen, and launched.

Fixes #26 