### PR TITLE
Don't cache wheels with pip install

### DIFF
--- a/appendix.txt
+++ b/appendix.txt
@@ -10,7 +10,7 @@ RUN cp ./binder/etc_dask_config.yaml /etc/dask/dask.yaml
 USER jovyan
 
 # Install Pangeo specific libraries
-RUN pip install bokeh dask-kubernetes nbserverproxy dask_labextension ipywidgets
+RUN pip install --no-cache-dir bokeh dask-kubernetes nbserverproxy dask_labextension ipywidgets
 
 # Install Pangeo specific Jupyter bits
 # serverextensions


### PR DESCRIPTION
This saves us some space and time. These wheels
will never be used anyway.