### PR TITLE
Install nbextensions into sys.prefix

### DIFF
--- a/appendix.txt
+++ b/appendix.txt
@@ -16,7 +16,7 @@ RUN pip install bokeh dask-kubernetes nbserverproxy dask_labextension ipywidgets
 # serverextensions
 RUN jupyter serverextension enable --sys-prefix --py nbserverproxy 
 # nbextensions
-RUN jupyter nbextension enable --py widgetsnbextension
+RUN jupyter nbextension enable --sys-prefix --py widgetsnbextension
 # labextensions
 RUN jupyter labextension install dask-labextension
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager


### PR DESCRIPTION
Otherwise they get put in $HOME, which causes problems
when you try to put persistent storage there.