### PR TITLE
Fix travis deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ script:
 
 deploy:
   provider: script
-  script: bash docker_push.sh
+  script:
+    - ./docker_push.sh base-notebook
+    - ./docker_push.sh pangeo-notebook
   on:
     branch: master
 

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-
-set -x
+set -euxo pipefail
 
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+
+IMAGE=${1}
 
 CALVER="$( date -u '+%Y.%m.%d' )"
 IMAGE_NAME=${IMAGE_PREFIX}${IMAGE}:${CALVER}


### PR DESCRIPTION
- Since we no longer matrix by image, we need to
  pass the image name explicitly to the docker push
  script
- Make bash fail on first error