### PR TITLE
Don't use --chown in onbuild variants

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -4,11 +4,14 @@ FROM $BASE_IMAGE_SPEC
 USER root
 COPY r2d_overlay.py /usr/local/bin/r2d_overlay.py
 
-ONBUILD COPY --chown=1000:1000 . ${REPO_DIR}
+# We aren't using --chown here since a bunch of binders
+# don't run new enough Docker for it.
+ONBUILD COPY . ${REPO_DIR}
 # We copy contents of *child* image to a subdirectory temporarily
 # This helps us apply customizations that were only from the
 # child, and re-do the packages of the parent.
-ONBUILD COPY --chown=1000:1000 . ${REPO_DIR}/.onbuild-child
+ONBUILD COPY . ${REPO_DIR}/.onbuild-child
+ONBUILD RUN chown -R 1000:1000 ${REPO_DIR}
 ONBUILD RUN /usr/local/bin/r2d_overlay.py build
 ONBUILD RUN rm -rf ${REPO_DIR}/.onbuild-child
 


### PR DESCRIPTION
Some binders don't have a new enough version of the
docker daemon running, because they are using the same docker
as running in GKE. This version is pretty old, so
--chown is not supported. This works around that
by manually running chown. This increases image size, but
works universally.

See https://github.com/pangeo-data/pangeo-stacks/issues/36