### PR TITLE
unpin repo2docker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 docker
 python-dateutil
 pytz
-# pinned r2d version to fix conda install problems
-git+git://github.com/jupyter/repo2docker.git@8dfd400c779763d0051975454050f22c1f19daf0
+repo2docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docker
 python-dateutil
 pytz
-repo2docker
+jupyter-repo2docker


### PR DESCRIPTION
This unpins repo2docker now that a few stable releases have passed. 