### PR TITLE
Bump Python, jlab, and tornado versions.

### DIFF
--- a/base-notebook/binder/environment.yml
+++ b/base-notebook/binder/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - nbserverproxy
   - ipywidgets
   - graphviz
-  - dask-labextension==0.3.1
+  - dask-labextension==0.3.3

--- a/base-notebook/binder/environment.yml
+++ b/base-notebook/binder/environment.yml
@@ -2,11 +2,11 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - jupyter
-  - jupyterlab
+  - jupyterlab=1.0.1
   - jupyterhub
-  - tornado=5.1.1
+  - tornado=6.0.3
   - bokeh
   - dask>=2.0.0
   - dask-kubernetes>=0.9.0

--- a/base-notebook/binder/postBuild
+++ b/base-notebook/binder/postBuild
@@ -7,7 +7,7 @@ jupyter serverextension enable --sys-prefix --py nbserverproxy
 jupyter nbextension enable --sys-prefix --py widgetsnbextension
 
 # labextensions
-jupyter labextension install dask-labextension@0.3.0 \
+jupyter labextension install dask-labextension@0.3.3 \
                              @jupyter-widgets/jupyterlab-manager \
                              @jupyterlab/hub-extension
                              

--- a/base-notebook/binder/postBuild
+++ b/base-notebook/binder/postBuild
@@ -7,7 +7,8 @@ jupyter serverextension enable --sys-prefix --py nbserverproxy
 jupyter nbextension enable --sys-prefix --py widgetsnbextension
 
 # labextensions
-jupyter labextension install dask-labextension@0.3.3 \
+
+jupyter labextension install dask-labextension@1.0.0-rc.0 \
                              @jupyter-widgets/jupyterlab-manager \
                              @jupyterlab/hub-extension
                              

--- a/base-notebook/binder/tests/test_imports.py
+++ b/base-notebook/binder/tests/test_imports.py
@@ -22,6 +22,6 @@ def test_pinned_versions():
     import dask_kubernetes
     import dask_labextension
 
-    assert LooseVersion(tornado.version) == LooseVersion('5.1.1')
-    assert LooseVersion(dask_kubernetes.__version__) >= LooseVersion('0.8')
-    assert LooseVersion(dask_labextension.__version__) == LooseVersion('0.3.1')
+    assert LooseVersion(tornado.version) == LooseVersion('6.0.3')
+    assert LooseVersion(dask_kubernetes.__version__) >= LooseVersion('0.9.0')
+    assert LooseVersion(dask_labextension.__version__) == LooseVersion('0.3.3')

--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -2,13 +2,14 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   # core scipy packages
   - numpy
   - scipy
   - matplotlib
   - pandas
   - xarray>=0.12.2
+  - dask>=2.0.0
   # data science stuff
   - scikit-image
   - scikit-learn


### PR DESCRIPTION
- python 3.6 -> 3.7
- jupyterlab -> 1.0.0
- tornado 5.1.1 -> 6.0.3