### PR TITLE
Pangeo notebook fix

### DIFF
--- a/base-notebook/binder/environment.yml
+++ b/base-notebook/binder/environment.yml
@@ -3,16 +3,16 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
-  - jupyterlab=1.*
-  - jupyterhub
-  - nbgitpuller
-  - dask>=2.2.0
-  - distributed>=2.2.0
-  - dask-kubernetes>=0.9.1
-  - tornado=6.*
-  - jupyter-server-proxy
-  - bokeh
-  - graphviz
-  - pip
+  - jupyterlab=1
+  - jupyterhub=1
+  - nbgitpuller=0.7
+  - dask=2.2
+  - distributed=2.2
+  - dask-kubernetes=0.9
+  - tornado=6
+  - jupyter-server-proxy=1.1
+  - bokeh=1.3
+  - graphviz=2.40
+  - pip=19
   - pip:
     - git+https://github.com/ian-r-rose/dask-labextension.git@de-asyncify#egg=dask_labextension

--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -2,21 +2,21 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+#  - python=3.7
   # core scipy packages
   - numpy
   - scipy
   - matplotlib
   - pandas
   - xarray>=0.12.2
-  - dask>=2.0.0
+#  - dask>=2.0.0
   # data science stuff
   - scikit-image
   - scikit-learn
   - dask-ml
-  - tensorflow
-  - keras
-  - pytorch-cpu
+#  - tensorflow
+#  - keras
+#  - pytorch-cpu
   # pyviz
   - holoviews
   - panel
@@ -60,5 +60,5 @@ dependencies:
   - xgcm
   - xrft
   - pip
-  - pip:
-    - git+https://github.com/intake/xrviz
+#  - pip:
+#    - git+https://github.com/intake/xrviz


### PR DESCRIPTION
i'm hoping this fixes our woes with https://github.com/pangeo-data/pangeo-cloud-federation/pull/362 .

I think we need to start pinning packages that are known to be compatible (TBD for pangeo-notebook). As far as I can tell there are some version incompatibilities w/ newly built images with the ML packages `tensorflow` and `keras`. And pip installing `xrviz` is bringing along a dated version of `holoviews`. Let's see if this fixes things for now.