### PR TITLE
Return ml libs

### DIFF
--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -2,21 +2,19 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
-#  - python=3.7
   # core scipy packages
   - numpy
   - scipy
   - matplotlib
   - pandas
   - xarray>=0.12.2
-#  - dask>=2.0.0
   # data science stuff
   - scikit-image
   - scikit-learn
   - dask-ml
-#  - tensorflow
-#  - keras
-#  - pytorch-cpu
+  - tensorflow
+  - keras
+  - pytorch-cpu
   # pyviz
   - holoviews
   - panel


### PR DESCRIPTION
Attempting to fix https://github.com/pangeo-data/pangeo-cloud-federation/issues/370 

In brief, we removed the ML libs because conda was giving errors such as 
`ERROR conda.core.link:_execute(637): An error occurred while installing package 'None'.
AssertionError()`
https://circleci.com/gh/pangeo-data/pangeo-cloud-federation/694

This was tricky to sort out, and I'm still not sure I understand what was going on, but at the time running repo2docker locally and removing the ML packages removed the error and allowed on-build variants on pangeo-cloud-federation to build. 

On one hand, the unpinned versions in pangeo-notebook should allow for compatible combinations. On the other, having many packages with complicated dependencies makes the environment hard to solve (or it seems prone to errors). 

But let's see if new package versions work this time. With our current setup a full test is hard, because it requires two steps: 1) building this image. 2) creating an on-build image on top of step1 (https://github.com/pangeo-data/pangeo-cloud-federation/blob/e6ec0b96222ae4cde4f34173c1390d3b8a555848/deployments/ocean/image/binder/Dockerfile#L2)

Thoughts @jhamman, @rabernat, @tjcrone  ?