### PR TITLE
add tiledb to notebook environment

### DIFF
--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -52,6 +52,7 @@ dependencies:
   - lz4
   - gcsfs
   - s3fs
+  - tiledb-py
   # jupyter-related
   - ipyleaflet
   # xarray-related


### PR DESCRIPTION
This will make it easier for us to test out tiledb on pango cloud environments.

cc @normanb