### PR TITLE
Add code to allow the use of binder/start

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -16,3 +16,6 @@ ONBUILD RUN /usr/local/bin/r2d_overlay.py build
 ONBUILD RUN rm -rf ${REPO_DIR}/.onbuild-child
 
 ONBUILD USER ${NB_USER}
+
+
+ENTRYPOINT /usr/local/bin/r2d_overlay.py start

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -17,5 +17,4 @@ ONBUILD RUN rm -rf ${REPO_DIR}/.onbuild-child
 
 ONBUILD USER ${NB_USER}
 
-
 ENTRYPOINT /usr/local/bin/r2d_overlay.py start

--- a/onbuild/r2d_overlay.py
+++ b/onbuild/r2d_overlay.py
@@ -109,6 +109,29 @@ def build():
                     ['/bin/bash', '-c', command], preexec_fn=applicator._pre_exec
                 )
 
+def start():
+    #Enable additional actions in the future
+    applicators = [apply_start]
+
+    for applicator in applicators:
+        commands = applicator()
+
+        if commands:
+            for command in commands:
+                subprocess.check_call(
+                    ['/bin/bash', '-c', command], preexec_fn=applicator._pre_exec
+                )
+
+@become(NB_UID)
+def apply_start():
+    st_path = binder_path('start')
+
+    if os.path.exists(st_path):
+        return [
+            f'chmod +x {st_path}',
+            # since pb_path is a fully qualified path, no need to add a ./
+            f'{st_path}'
+        ]
 
 def main():
     argparser = argparse.ArgumentParser()
@@ -121,8 +144,9 @@ def main():
 
     if args.action == 'build':
         build()
-    else:
-        raise Exception("start isn't implemented yet")
+    elif args.action == 'start':
+        start()
+
 
 if __name__ == '__main__':
     main()

--- a/onbuild/r2d_overlay.py
+++ b/onbuild/r2d_overlay.py
@@ -132,6 +132,8 @@ def apply_start():
             # since pb_path is a fully qualified path, no need to add a ./
             f'{st_path}'
         ]
+    else:
+        return [f'/usr/local/bin/repo2docker-entrypoint']
 
 def main():
     argparser = argparse.ArgumentParser()


### PR DESCRIPTION
This PR may need some editing but gives some base code to allow those who build pangeo binders to use the base binder images as a starter AND use binder/start at the same time. 