### PR TITLE
Add support for .binder directories

### DIFF
--- a/onbuild/r2d_overlay.py
+++ b/onbuild/r2d_overlay.py
@@ -23,11 +23,24 @@ def become(uid):
         return func
     return wrap
 
-
 def binder_path(path):
-    if os.path.exists(os.path.join(ONBUILD_CONTENTS_DIR, 'binder')):
-        return os.path.join(ONBUILD_CONTENTS_DIR, 'binder', path)
-    return os.path.join(ONBUILD_CONTENTS_DIR, path)
+    has_binder = os.path.isdir(os.path.join(ONBUILD_CONTENTS_DIR, "binder"))
+    has_dotbinder = os.path.isdir(os.path.join(ONBUILD_CONTENTS_DIR, ".binder"))
+
+    if has_binder and has_dotbinder:
+        raise RuntimeError(
+            "The repository contains both a 'binder' and a '.binder' "
+            "directory. However they are exclusive."
+        )
+
+    if has_dotbinder:
+        binder_dir =  ".binder"
+    elif has_binder:
+        binder_dir = "binder"
+    else:
+        binder_dir = ""
+
+    return os.path.join(ONBUILD_CONTENTS_DIR, binder_dir, path)
 
 
 @become(NB_UID)


### PR DESCRIPTION
Steal code directly from repo2docker to match behavior:

https://github.com/jupyter/repo2docker/blob/4f428c305576ccf1f1ff1fb18b11bbf1402ca7bd/repo2docker/buildpacks/base.py#L478

Ref https://github.com/pangeo-data/pangeo-cmip6-examples/issues/7#issuecomment-532491546