### PR TITLE
fix dockerhub link

### DIFF
--- a/docs/build_stacks_rst.py
+++ b/docs/build_stacks_rst.py
@@ -137,7 +137,7 @@ class StacksRSTBuilder:
 
             conda_list = self.conda_list(image)
 
-            metadata = {'URL': f'https://hub.docker.com/r/pangeo/{image}'}
+            metadata = {'URL': f'https://hub.docker.com/r/{image}'}
             metadata.update(self.docker_inspect(image))
 
             id = image.split('/')[1]


### PR DESCRIPTION
The docker links are broken on the website:
https://pangeo-data.github.io/pangeo-stacks/images.html#pangeo-pangeo-notebook

They look like 
```
https://hub.docker.com/r/pangeo/pangeo/pangeo-notebook
```

This removes the duplicate pangeo.