### PR TITLE
bump dask to 2.8.1, add optional worker lifetime config

### DIFF
--- a/base-notebook/binder/dask_config.yaml
+++ b/base-notebook/binder/dask_config.yaml
@@ -11,8 +11,11 @@ distributed:
     idle-timeout: 3600s
   
   worker:
-    lifetime: "5 hours"
-  
+    lifetime:
+      duration: "5 hours"
+      stagger: "10 s"
+      restart: true
+
   admin:
     tick:
       limit: 5s

--- a/base-notebook/binder/dask_config.yaml
+++ b/base-notebook/binder/dask_config.yaml
@@ -10,6 +10,9 @@ distributed:
   scheduler:
     idle-timeout: 3600s
   
+  worker:
+    lifetime: "5 hours"
+  
   admin:
     tick:
       limit: 5s

--- a/base-notebook/binder/dask_config.yaml
+++ b/base-notebook/binder/dask_config.yaml
@@ -9,12 +9,13 @@ distributed:
 
   scheduler:
     idle-timeout: 3600s
-  
-  worker:
-    lifetime:
-      duration: "5 hours"
-      stagger: "10 s"
-      restart: true
+
+# uncomment to force new worker pods after 2 hrs
+#  worker:
+#    lifetime:
+#      duration: "2 hours"
+#      stagger: "10 s"
+#      restart: true
 
   admin:
     tick:

--- a/base-notebook/binder/environment.yml
+++ b/base-notebook/binder/environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - jupyterhub=1.0
   - jupyter-server-proxy=1.1
   - nbgitpuller=0.7
-  - dask=2.7
-  - distributed=2.7
+  - dask=2.8
+  - distributed=2.8
   - dask-kubernetes=0.10
   - dask-labextension=1.0
   - dask-gateway=0.5


### PR DESCRIPTION
This adds a maximum worker pod lifetime of 5 hours, which is a solution to cases where dask pods get stuck in `Running` states:
https://github.com/pangeo-data/pangeo-cloud-federation/issues/408#issuecomment-555169379 

```
  worker:
    lifetime: "5 hours"
```

Do people think this is ok? Willing to wait and see if other solutions come up in the above issue.
