### PR TITLE
Try with prepopulated esip container on dockerhub

### DIFF
--- a/pangeo-esip/binder/environment.yml
+++ b/pangeo-esip/binder/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - cartopy
   - geopandas
   - sat-search
+  - sat-stac
   - rasterio
   - regionmask
   - rio-cogeo

--- a/pangeo-esip/binder/environment.yml
+++ b/pangeo-esip/binder/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - iris
   - cartopy
   - geopandas
-  - intake-stac
   - sat-search
   - rasterio
   - regionmask
@@ -58,6 +57,7 @@ dependencies:
   - intake
   - intake-xarray
   - intake-esm
+  - intake-stac
   # zarr-related
   - zarr
   - numcodecs


### PR DESCRIPTION
I tagged `pangeo/pangeo-notebook:latest` as `pangeo/pangeo-esip:2019.11.20` to "seed" dockerhub since the CI expects a container to already exist. 