### PR TITLE
push ESIP first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,11 @@ deploy:
     on:
       branch: master
   - provider: script
-    script: bash docker_push.sh pangeo-notebook
+    script: bash docker_push.sh pangeo-esip
     on:
       branch: master
   - provider: script
-    script: bash docker_push.sh pangeo-esip
+    script: bash docker_push.sh pangeo-notebook
     on:
       branch: master
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,12 @@ deploy:
     script: bash docker_push.sh pangeo-esip
     on:
       branch: master
+      condition: $TRAVIS_JOB_NAME = 'pangeo-esip'
   - provider: script
     script: bash docker_push.sh pangeo-notebook
     on:
       branch: master
+      condition: $TRAVIS_JOB_NAME = 'pangeo-notebook'
   - provider: script
     script: bash ./docs/build_docs.sh && bash ./docs/publish_docs.sh
     on:


### PR DESCRIPTION
The pangeo-notebook fails on/off to solve for the environment but the pangeo-esip does not. Let's deploy the latter first so we can help @rsignell-usgs get an image for his demo in January.

PS: I'm also checking why the pangeo-notebook is failing to solve in an acceptable amount of time. That is a conda problem regardless of the CI used here.