### PR TITLE
Bump dask versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Pangeo Stacks
 =============
 *Currated Docker images for use with Jupyter and [Pangeo](http://pangeo.io/)*
 
-[![Build Status](https://travis-ci.org/pangeo-data/pangeo-stacks.svg?branch=master)](https://travis-ci.org/pangeo-data/pangeo-stacks)
+![Action Status](https://github.com/pangeo-data/pangeo-stacks/workflows/MasterBuild/badge.svg)
 
 This repository contains a few currated Docker images that can be used with deployments of the [Pangeo Helm Chart](https://github.com/pangeo-data/helm-chart). Each of the images in this repository are configured and built using [repo2docker](https://repo2docker.readthedocs.io) and are continuously deployed to DockerHub. Importantly, each image built in this repo includes the minimum required libraries to do scalable computations with Pangeo (via dask-kubernetes).
 

--- a/base-notebook/binder/environment.yml
+++ b/base-notebook/binder/environment.yml
@@ -4,15 +4,15 @@ channels:
   - conda-forge
 dependencies:
   - jupyterlab=1.2
-  - jupyterhub=1.0
+  - jupyterhub=1.1
   - jupyter-server-proxy=1.2
   - nbgitpuller=0.8
-  - dask=2.9
-  - distributed=2.9
+  - dask=2.10
+  - distributed=2.10
   - dask-kubernetes=0.10
   - dask-gateway=0.6
-  - dask-labextension=1
-  - tornado=6
+  - dask-labextension=1.1
+  - tornado=6.0
   - bokeh=1.4
   - python-graphviz=0.13
-  - pip=19.3
+  - pip=20.0


### PR DESCRIPTION
also updated readme to point to new GitHub action status instead of travis