### PR TITLE
remove dup geoviews

### DIFF
--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -23,7 +23,6 @@ dependencies:
   - jupyter-panel-proxy
   - geoviews
   - hvplot
-  - geoviews
   - datashader
   - seaborn
   - altair


### PR DESCRIPTION
Keep the duplication is harmless but I guess it is good practice to remove it.

PS: the comments and order of the packages in this file are nice for a human-scientist to read and understand what is used for that. However, as someone that is reading this more and more to debug problems, I'd like to propose to remove the comments and put the packages in alphabetical order. It will help people like me to debug install conflicts quicker. If people here are OK with that I can send another PR with these changes.