### PR TITLE
use mpl base instead of the gui mpl

### DIFF
--- a/pangeo-esip/binder/environment.yml
+++ b/pangeo-esip/binder/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   # core scipy 
   - numpy
   - scipy
-  - matplotlib
+  - matplotlib-base
   - pandas
   - xarray
   - python-gist

--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   # core scipy packages
   - numpy
   - scipy
-  - matplotlib
+  - matplotlib-base
   - pandas
   - xarray
   - sparse


### PR DESCRIPTION
This should reduce the image size b/c it won't install GUI stuff that is not needed for `jupyter`/`jupyterlab`. Other packages listed will still pull `matplotlib` though and I'm working on that upstream so people can benefit from this `matplotlib-base`.