### PR TITLE
repo2docker 0.11 up from 0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 docker==4.1.0
 python-dateutil==2.8.1
 pytz==2019.3
-jupyter-repo2docker==0.10.0
+jupyter-repo2docker==0.11.0
 sphinx==1.6.5
 rstcloth==0.2.6
 doctr==1.8.0


### PR DESCRIPTION
Try rebuilding images with latest release of repo2docker now on pypi https://github.com/jupyter/repo2docker/releases 