### PR TITLE
fix dask container name

### DIFF
--- a/base-notebook/binder/dask_config.yaml
+++ b/base-notebook/binder/dask_config.yaml
@@ -35,7 +35,7 @@ kubernetes:
       serviceAccount: daskkubernetes
       restartPolicy: Never
       containers:
-        - name: dask-${JUPYTERHUB_USER}
+        - name: dask-worker
           image: ${JUPYTER_IMAGE_SPEC}
           args:
             - dask-worker


### PR DESCRIPTION
fixes error for users creating clusters with underscore characters in their github user name or binder repositories with underscores:

https://github.com/dask/dask-kubernetes/issues/230 