### PR TITLE
bump dask and distributed to 2.11

### DIFF
--- a/base-notebook/binder/environment.yml
+++ b/base-notebook/binder/environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - jupyterhub=1.1
   - jupyter-server-proxy=1.2
   - nbgitpuller=0.8
-  - dask=2.10
-  - distributed=2.10
+  - dask=2.11
+  - distributed=2.11
   - dask-kubernetes=0.10
   - dask-gateway=0.6
   - dask-labextension=1.1


### PR DESCRIPTION
fixes errors due to compatibility with msgpack 1.0 (https://github.com/dask/distributed/pull/3494)