### PR TITLE
nomkl

### DIFF
--- a/pangeo-esip/binder/environment.yml
+++ b/pangeo-esip/binder/environment.yml
@@ -2,6 +2,7 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
+  - nomkl
   - pandoc
   # core scipy 
   - numpy

--- a/pangeo-ml/binder/environment.yml
+++ b/pangeo-ml/binder/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - rapidsai-nightly
 dependencies:
+  - nomkl
   # core scipy packages
   - numpy
   - scipy

--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -2,6 +2,7 @@ name: pangeo
 channels:
   - conda-forge
 dependencies:
+  - nomkl
   # core scipy packages
   - numpy
   - scipy


### PR DESCRIPTION
I did not test this with the `pangeoml` yet, the `pangeo-esip` was not installing `mkl`, and the `pangeo-notebook` was installing it and its size went from 2.5G to 1.8G with `nomkl`. The details of the env I used to test are in:

https://gist.github.com/ocefpaf/ddc4088a6382054b9065e08465b0e71b

Note that I added `nomkl` in the esip env anyways to ensure `mkl` won't be installed there unless explicitly required in the environment.

I'm testing the `pangeoml` at this moment and I'll amend this PR if it is possible to use `nomkl` there as well.

Supersedes: https://github.com/pangeo-data/pangeo-stacks/pull/131
Helps with: https://github.com/pangeo-data/pangeo-stacks/issues/22