### PR TITLE
adding python-gist and nbstripout to env

### DIFF
--- a/pangeo-notebook/binder/environment.yml
+++ b/pangeo-notebook/binder/environment.yml
@@ -87,6 +87,8 @@ dependencies:
   # misc
   - python-wget
   - prefect
+  - python-gist
+  - nbstripout
   - pip:
     - intake_geopandas
     - git+https://github.com/NCAR/intake-esm.git@master


### PR DESCRIPTION
/condalock
* `python-gist` is what I use for creating gists from JupyterLab
* `nbstripout` for stripping output from notebooks prior to git commit

