### PR TITLE
Bump dask-gateway to 0.8

### DIFF
--- a/base-notebook/binder/environment.yml
+++ b/base-notebook/binder/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - dask=2.11
   - distributed=2.11
   - dask-kubernetes=0.10
-  - dask-gateway=0.6
+  - dask-gateway=0.8
   - dask-labextension=1.1
   - tornado=6
   - bokeh=1.4


### PR DESCRIPTION
The pangeo helm package installs `dask-gateway` 0.8.0